### PR TITLE
package.json license identifer

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "VMS IDE is an extension that enables you to develop applications for OpenVMS.",
     "version": "1.5.40",
     "publisher": "VMSSoftwareInc",
-    "license": "SEE LICENSE IN LICENSE.md",
+    "license": "MIT",
     "repository": {
         "type": "git",
         "url": "git:"


### PR DESCRIPTION
The vsix docs mentioned the currently used "SEE LICENSE in..." but refers to npm which says:

> You should specify a license for your package so that people know how they are permitted to use it, and any restrictions you're placing on it.
> If you're using a common license such as BSD-2-Clause or MIT, add a current SPDX license identifier for the license you're using, 
> `{ "license" : "BSD-3-Clause" }`, like this:
> [...] If you are using a license that hasn't been assigned an SPDX identifier, or if you are using a custom license, use a string value like this one:
> `{ "license" : "SEE LICENSE IN <filename>" }`
> Then include a file named <filename> at the top level of the package.

This PR is therefore in accordance to the documentation.